### PR TITLE
Fixes nomethod for [] error

### DIFF
--- a/lib/payload/utils.rb
+++ b/lib/payload/utils.rb
@@ -7,7 +7,7 @@ module Payload
 	def self.get_cls(data)
 		match = nil
 		for cls in subclasses(Payload::ARMObject)
-			if cls.spec['object'] != data['object']
+			if cls.spec&.fetch('object') != data['object']
 				next
 			end
 


### PR DESCRIPTION
class.spec is not guaranteed to return a hash.
Replace with safe navigation method.

NoMethodError: undefined method `[]' for nil:NilClass from .bundle/ruby/2.7.0/gems/payload-api-0.2.2/lib/payload/utils.rb:10:in `block in get_cls'