### PR TITLE
Updates ARMRequest._request to not pluralize resources ending in 's'

### DIFF
--- a/lib/payload/arm/request.rb
+++ b/lib/payload/arm/request.rb
@@ -179,12 +179,14 @@ module Payload
 				if @cls.spec.key?("endpoint")
 					endpoint = @cls.spec["endpoint"]
 				else
-					endpoint = "/"+@cls.spec["object"]+"s"
+					obj = @cls.spec["object"]
+					endpoint = "/" + (obj.end_with?("s") ? obj : obj + "s")
 				end
 			else
 				if json.is_a? Array
 					if json.all? {|obj| obj.key?("object") }
-						endpoint = json[0]["object"]+"s"
+						obj = json[0]["object"]
+						endpoint = (obj.end_with?("s") ? obj : obj + "s")
 					end
 				end
 			end

--- a/lib/payload/version.rb
+++ b/lib/payload/version.rb
@@ -1,3 +1,3 @@
 module Payload
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
 end

--- a/spec/payload/arm/request_spec.rb
+++ b/spec/payload/arm/request_spec.rb
@@ -1017,4 +1017,41 @@ RSpec.describe Payload::ARMRequest do
             end
         end
     end
+
+    describe "default endpoint pluralization (object name → path)" do
+        context "when spec object name ends with 's'" do
+            it "uses object name as path segment without appending 's'" do
+                klass = Class.new(Payload::ARMObject) do
+                    @spec = { "object" => "processing_settings" }
+                end
+                session = Payload::Session.new("test_key", "https://api.test.com")
+                instance = Payload::ARMRequest.new(klass, session)
+
+                expect(instance).to receive(:_execute_request) do |_http, request|
+                    expect(request.path).to start_with("/processing_settings/")
+                    expect(request.path).not_to include("processing_settingss")
+                    double(code: "200", body: '{"object":"processing_settings","id":"ps_123"}')
+                end
+
+                instance.get("ps_123")
+            end
+        end
+
+        context "when spec object name does not end with 's'" do
+            it "appends 's' to build path segment" do
+                klass = Class.new(Payload::ARMObject) do
+                    @spec = { "object" => "transaction" }
+                end
+                session = Payload::Session.new("test_key", "https://api.test.com")
+                instance = Payload::ARMRequest.new(klass, session)
+
+                expect(instance).to receive(:_execute_request) do |_http, request|
+                    expect(request.path).to start_with("/transactions/")
+                    double(code: "200", body: '{"object":"transaction","id":"txn_456"}')
+                end
+
+                instance.get("txn_456")
+            end
+        end
+    end
 end


### PR DESCRIPTION
Updates endpoint building to match the [Python SDK logic](https://github.com/payload-code/payload-python/blob/master/payload/arm/object.py#L23) WRT not pluralizing resources that already end in "s" - the issue this fixes was the `ProcessingSettings` endpoint built was `/processing_settingss` because it that resource spec delineated the object as ending in "s"