### PR TITLE
Fix Session#create(single ARMObject) raising on nil.poly

### DIFF
--- a/lib/payload/arm/request.rb
+++ b/lib/payload/arm/request.rb
@@ -152,6 +152,10 @@ module Payload
 
 				data = { object: 'list', values: data }
 			else
+				if data.kind_of?(ARMObject)
+					@cls = data.class
+					data = data.data
+				end
 				if @cls.poly
 					data = data.merge(@cls.poly)
 				end

--- a/spec/payload/arm/request_spec.rb
+++ b/spec/payload/arm/request_spec.rb
@@ -299,6 +299,59 @@ RSpec.describe Payload::ARMRequest do
                 expect(customers[2].session).to eq(instance.instance_variable_get(:@session))
             end
         end
+
+        context "when the user creates a single ARMObject via Session#create" do
+            it "executes the appropriate request and returns the appropriate object" do
+
+                $test_access_token = 'tok_' + rand(900000..999999).to_s
+                $test_refresh_token = 'ref_' + rand(900000..999999).to_s
+
+                Payload::api_key = 'test_key'
+                session = Payload::Session.new('test_key', 'https://api.payload.com')
+
+                oauth_token = Payload::OAuthToken.new(
+                    code: 'auth_code_123',
+                    grant_type: 'authorization_code',
+                    client_id: 'org_abc',
+                    client_secret: 'secret_key_xyz'
+                )
+
+                expect_any_instance_of(Payload::ARMRequest).to receive(:_execute_request) do |_req, http, request|
+                    expect(request.method).to eq("POST")
+                    expect(http.address).to eq("api.payload.com")
+                    expect(Base64.decode64(request['authorization'].split(' ')[1]).split(':')[0]).to eq('test_key')
+                    expect(request.path).to eq("/oauth/token?")
+                    expect(request.body).to eq("{\"code\":\"auth_code_123\",\"grant_type\":\"authorization_code\",\"client_id\":\"org_abc\",\"client_secret\":\"secret_key_xyz\"}")
+
+                    class MockResponse
+                        def initialize
+                        end
+
+                        def code
+                            '200'
+                        end
+
+                        def body
+                            '{
+                                "object": "oauth_token",
+                                "access_token": "' + $test_access_token + '",
+                                "refresh_token": "' + $test_refresh_token + '"
+                            }'
+                        end
+                    end
+
+                    MockResponse.new
+                end
+
+                result = session.create(oauth_token)
+
+                expect(result).to be_a(Payload::OAuthToken)
+                expect(result.object).to eq("oauth_token")
+                expect(result.access_token).to eq($test_access_token)
+                expect(result.refresh_token).to eq($test_refresh_token)
+                expect(result.session).to eq(session)
+            end
+        end
     end
 
     describe "#get" do

--- a/spec/payload/arm/request_spec.rb
+++ b/spec/payload/arm/request_spec.rb
@@ -307,14 +307,7 @@ RSpec.describe Payload::ARMRequest do
                 $test_refresh_token = 'ref_' + rand(900000..999999).to_s
 
                 Payload::api_key = 'test_key'
-                session = Payload::Session.new('test_key', 'https://api.payload.com')
-
-                oauth_token = Payload::OAuthToken.new(
-                    code: 'auth_code_123',
-                    grant_type: 'authorization_code',
-                    client_id: 'org_abc',
-                    client_secret: 'secret_key_xyz'
-                )
+                pl = Payload::Session.new('test_key', 'https://api.payload.com')
 
                 expect_any_instance_of(Payload::ARMRequest).to receive(:_execute_request) do |_req, http, request|
                     expect(request.method).to eq("POST")
@@ -343,13 +336,18 @@ RSpec.describe Payload::ARMRequest do
                     MockResponse.new
                 end
 
-                result = session.create(oauth_token)
+                oauth_token = pl.create(Payload::OAuthToken.new({
+                    code: 'auth_code_123',
+                    grant_type: 'authorization_code',
+                    client_id: 'org_abc',
+                    client_secret: 'secret_key_xyz'
+                }))
 
-                expect(result).to be_a(Payload::OAuthToken)
-                expect(result.object).to eq("oauth_token")
-                expect(result.access_token).to eq($test_access_token)
-                expect(result.refresh_token).to eq($test_refresh_token)
-                expect(result.session).to eq(session)
+                expect(oauth_token).to be_a(Payload::OAuthToken)
+                expect(oauth_token.object).to eq("oauth_token")
+                expect(oauth_token.access_token).to eq($test_access_token)
+                expect(oauth_token.refresh_token).to eq($test_refresh_token)
+                expect(oauth_token.session).to eq(pl)
             end
         end
     end


### PR DESCRIPTION
# Description

When following the [OAuth Connect docs](https://docs.payload.com/ui/oauth-connect/) and calling `pl.create(Payload::OAuthToken.new({...}))` to exchange an authorization code for tokens, the SDK raised `NoMethodError: undefined method 'poly' for nil:NilClass`. `Session#create` builds an `ARMRequest` with no resource class (`@cls` nil). The single-object path in `ARMRequest#create` then called `@cls.poly` without setting `@cls`, causing the error.

Fix: In the single-object branch, when the argument is an `ARMObject`, set `@cls` from the instance and use its `.data` for the request body; only merge `@cls.poly` when `@cls` is set.

Changes include:

- [x] In `ARMRequest#create` else branch: if `data` is an `ARMObject`, set `@cls = data.class` and `data = data.data` before the poly check
- [x] Add spec for `Session#create` with a single ARMObject (OAuthToken flow) to reproduce and guard against the bug

## Type of change

- Bug fix (non-breaking change which fixes an issue)